### PR TITLE
Delete .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "swig"]
-	path = swig-of
-url=https://github.com/danomatika/swig-openframeworks.git


### PR DESCRIPTION
Swig submodule is not longer needed, and can cause issues in some build pipelines